### PR TITLE
鬱 上海讀 iuq/iuih

### DIFF
--- a/wugniu_zaonhe.dict.yaml
+++ b/wugniu_zaonhe.dict.yaml
@@ -5370,7 +5370,6 @@ use_preset_vocabulary: true
 役	yoq
 鬻	yoq
 聿	yoq
-鬱	ioq
 郁	ioq
 不	peq
 缽	peq

--- a/wugniu_zaonhe_laupha.dict.yaml
+++ b/wugniu_zaonhe_laupha.dict.yaml
@@ -4473,7 +4473,7 @@ use_preset_vocabulary: true
 慾	yoq
 欲	yoq
 浴	yoq
-鬱	ioq
+鬱	ioeq
 郁	ioq
 畝	m
 母	m


### PR DESCRIPTION
偶然看到個。可能是繁簡轉換個辰光搭「郁ioh」混同了？據我所知鬱只有一個讀音iuih。雖然弗大清爽㑚個laupha字典是按照啥個來源，不過我看中派讀iuih個儕歸到老派ioeh裏向了。所以我拏老派字典一道改脫哉。