### PR TITLE
zaonhe.dict: 車：降低讀音「ciu」的權重

### DIFF
--- a/wugniu_zaonhe.dict.yaml
+++ b/wugniu_zaonhe.dict.yaml
@@ -1309,7 +1309,7 @@ use_preset_vocabulary: true
 縷	liu
 膂	liu
 居	ciu
-車	ciu
+車	ciu	4%
 拘	ciu
 駒	ciu
 裾	ciu


### PR DESCRIPTION
目前輸入 `ciu` 出來的第一位是「車」，顯然太高了……