### PR TITLE
schema: 重命名 simplifier，使之不影響其他輸入方案（例如朙月拼音）

### DIFF
--- a/wugniu_sonkaon.schema.yaml
+++ b/wugniu_sonkaon.schema.yaml
@@ -23,7 +23,7 @@ switches:
     states: [ 中文, 西文 ]
   - name: full_shape
     states: [ 半角, 全角 ]
-  - name: simplification
+  - name: wugniu_zaonhe_simp
     reset: 1
     states: [ 漢字, 汉字 ]
   - name: ascii_punct
@@ -144,6 +144,9 @@ reverse_lookup:
   tags: [luna_pinyin, stroke] # 掛在翻譯器luna_pinyin和stroke上
   overwrite_comment: true     # 覆蓋其他提示
   dictionary: wugniu_sonkaon  # 反查所得爲松江吳拼
+
+simplifier:
+  option_name: wugniu_zaonhe_simp
 
 punctuator:
   import_preset: symbols # 句讀處理器，統一從外部導入

--- a/wugniu_zaonhe.schema.yaml
+++ b/wugniu_zaonhe.schema.yaml
@@ -26,7 +26,7 @@ switches:
     states: [ 中文, 西文 ]
   - name: full_shape
     states: [ 半角, 全角 ]
-  - name: simplification
+  - name: wugniu_zaonhe_simp
     reset: 1
     states: [ 漢字, 汉字 ]
   - name: ascii_punct
@@ -160,6 +160,9 @@ reverse_lookup:
   tags: [luna_pinyin, stroke] # 掛在翻譯器luna_pinyin和stroke上
   overwrite_comment: true     # 覆蓋其他提示
   dictionary: wugniu_zaonhe   # 反查所得爲上海吳拼
+
+simplifier:
+  option_name: wugniu_zaonhe_simp
 
 punctuator:
   import_preset: symbols # 句讀處理器，統一從外部導入

--- a/wugniu_zaonhe_laupha.schema.yaml
+++ b/wugniu_zaonhe_laupha.schema.yaml
@@ -22,7 +22,7 @@ switches:
     states: [ 中文, 西文 ]
   - name: full_shape
     states: [ 半角, 全角 ]
-  - name: simplification
+  - name: wugniu_zaonhe_simp
     reset: 1
     states: [ 漢字, 汉字 ]
   - name: ascii_punct
@@ -129,6 +129,9 @@ reverse_lookup:
   tags: [luna_pinyin, stroke]      # 掛在翻譯器luna_pinyin和stroke上
   overwrite_comment: true          # 覆蓋其他提示
   dictionary: wugniu_zaonhe_laupha # 反查所得爲吳拼
+
+simplifier:
+  option_name: wugniu_zaonhe_simp
 
 punctuator:
   import_preset: symbols # 句讀處理器，統一從外部導入


### PR DESCRIPTION
當前，本倉庫中的方案的 `simplifier` 使用的開關名稱爲 `simplification`（默認值），而 `reset: 1` 指定了切換到某方案時，重設此開關狀態爲「啓用『繁→簡』轉換」。假設有一個人習慣使用朙月拼音（或其他使用默認名稱 `simplification` 的方案）輸入繁體，在 ta 切換到本倉庫中的方案，再切換回朙月拼音後，`simplifier` 將會保留「啓用『繁→簡』轉換」的狀態，略有不便。

此修改（參照了 [luna_pinyin_simp.schema](https://github.com/rime/rime-luna-pinyin/blob/1b3a2e58cd45e556efafb39c672fe8cb7ada3461/luna_pinyin_simp.schema.yaml) 的做法）將本倉庫中的方案的 `simplifier` 之開關更名，使之不再影響其他輸入方案。

（本修改仍然維持了倉庫下各方案共用相同的 `simplifier` 開關名，因爲推測同時使用本倉庫中多個方案且需要不同繁簡設置的用戶數量較少。如果有用戶需要獨立的開關，也可以打補丁把三個 schema 的 simplifier 改成不一樣的。）